### PR TITLE
Adds an "existing user" button to the profile login

### DIFF
--- a/src/components/soundshed/login.tsx
+++ b/src/components/soundshed/login.tsx
@@ -61,7 +61,13 @@ const LoginControl = ({ signInRequired, onSignIn , onRegistration}) => {
                 New User
               </Button>
             ) : (
-              ""
+              <Button className="btn btn-sm btn-secondary ms-2"
+                onClick={() => {
+                  setIsRegMode(false);
+                }}
+              >
+                Existing User
+              </Button>
             )}
           </p>
 


### PR DESCRIPTION
Fix for #15 where currently there is no way to navigate back to the "Existing User" profile window

Edit: not sure whats causing these action failures but I imagine its not something to do with the code I'm providing and probably some CI action keys I wouldn't have access to?

![Soundshed](https://user-images.githubusercontent.com/7063963/111088678-40f24900-8520-11eb-8826-d46d7301995d.jpg)
