### PR TITLE
[WIP] Add Green 1 channel button for Spark 2

### DIFF
--- a/src/components/device/misc-controls.tsx
+++ b/src/components/device/misc-controls.tsx
@@ -113,6 +113,20 @@ const MiscControls = ({
             >
               4
             </button>
+            <button
+              type="button"
+              className={
+                selectedChannel == 4
+                  ? "btn btn-sm btn-secondary active"
+                  : "btn btn-sm btn-secondary"
+              }
+              id="ch5"
+              onClick={() => {
+                setChannel(4);
+              }}
+            >
+              Green 1
+            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Just a demonstration on how I managed to control Green Channel 1 preset on my Spark 2. Now we need to identify the Spark 2 (any other amps?) connection to display green channel buttons only when these channels are available.